### PR TITLE
run: Add test pattern to help text

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,7 +63,7 @@ var (
 
 // listCmd represents the list command
 var runCmd = &cobra.Command{
-	Use:   "run",
+	Use:   "run [test pattern]",
 	Short: "A brief description of your command",
 	RunE:  run,
 }


### PR DESCRIPTION
Users had reported that this was missing and therefore assumed the
functionality wasn't implemented

Signed-off-by: Dave Tucker <dt@docker.com>