### PR TITLE
Change label check logic to look for only one match

### DIFF
--- a/local/labels.go
+++ b/local/labels.go
@@ -28,12 +28,20 @@ func ParseLabels(labels string) (map[string]bool, map[string]bool) {
 
 // WillRun determines if a group or test should run based on its labels and the RunConfig
 func WillRun(labels, notLabels map[string]bool, config RunConfig) bool {
-	// 2. Check every test label is in the hostLabels
-	for l := range labels {
-		if _, ok := config.Labels[l]; !ok {
+	// 1. If test has labels
+	if len(labels) > 0 {
+		// 2. Check that at least one test label is in the hostLabels
+		matches := 0
+		for l := range labels {
+			if _, ok := config.Labels[l]; ok {
+				matches++
+			}
+		}
+		if matches == 0 {
 			return false
 		}
 	}
+
 	// 3. Check every test notLabel is NOT in the hostLabels
 	for l := range notLabels {
 		if _, ok := config.Labels[l]; ok {

--- a/local/labels_test.go
+++ b/local/labels_test.go
@@ -19,3 +19,37 @@ func TestParseLabels(t *testing.T) {
 		t.Fatalf("\nExpected %+v\nGot: %+v\n", expectedUnSet, unSet)
 	}
 }
+
+func TestWillRun(t *testing.T) {
+
+	darwin := map[string]bool{"darwin": true}
+	linux := map[string]bool{"linux": true}
+	both := map[string]bool{"darwin": true, "linux": true}
+
+	darwinUser := RunConfig{Labels: darwin}
+	linuxUser := RunConfig{Labels: linux}
+
+	if !WillRun(nil, nil, RunConfig{}) {
+		t.Fatalf("Test with no labels on host with no labels doesn't run")
+	}
+
+	if !WillRun(nil, nil, darwinUser) {
+		t.Fatalf("Test with no labels doesn't run!")
+	}
+
+	if !WillRun(darwin, nil, darwinUser) {
+		t.Fatalf("Darwin test doesn't run for darwin user")
+	}
+
+	if !WillRun(linux, nil, linuxUser) {
+		t.Fatalf("Linux test doesn't run for linux user")
+	}
+
+	if WillRun(darwin, nil, linuxUser) {
+		t.Fatalf("Darwin test runs for linuxUser")
+	}
+
+	if !WillRun(both, nil, darwinUser) {
+		t.Fatalf("Test on darwin/linux doesn't run for darwin user")
+	}
+}


### PR DESCRIPTION
Not all labels given to a test are required to be present.
Only one is required.
Add tests to ensure this is honoured.

Fixes: #16

Signed-off-by: Dave Tucker <dt@docker.com>