### PR TITLE
Fix test sorting for mixed tests/subgroups

### DIFF
--- a/local/test.go
+++ b/local/test.go
@@ -60,7 +60,7 @@ func (t *Test) Init() error {
 			t.NotLabels[k] = v
 		}
 	}
-	t.Order = order
+	t.order = order
 	return nil
 }
 
@@ -72,6 +72,23 @@ func (t *Test) Name() string {
 // LabelString returns all labels in a comma separated string
 func (t *Test) LabelString() string {
 	return makeLabelString(t.Labels, t.NotLabels)
+}
+
+// List satisfies the TestContainer interface
+func (t *Test) List(config RunConfig) []Result {
+	if WillRun(t.Labels, t.NotLabels, config) && CheckPattern(t.Name(), config.TestPattern) {
+		return []Result{{
+			Name:    t.Name(),
+			Summary: t.Tags.Summary,
+			Labels:  t.LabelString(),
+		}}
+	}
+	return []Result{{
+		TestResult: Skip,
+		Name:       t.Name(),
+		Summary:    t.Tags.Summary,
+		Labels:     t.LabelString(),
+	}}
 }
 
 // Run runs a test
@@ -140,4 +157,9 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 		results = append(results, res)
 	}
 	return results, nil
+}
+
+// Order returns a tests order
+func (t *Test) Order() int {
+	return t.order
 }

--- a/local/test_test.go
+++ b/local/test_test.go
@@ -13,10 +13,21 @@ func TestFindingTests(t *testing.T) {
 	if err := p.Init(); err != nil {
 		t.Fatal(err)
 	}
+
+	expected := []Result{
+		{Name: "test.osx"},
+		{Name: "test.win"},
+		{Name: "test.apps.test"},
+		{Name: "test.apps.basic.test"},
+		{Name: "test.apps.advanced.test"},
+	}
+
 	config := RunConfig{}
 	l := p.List(config)
-	for _, tst := range l {
-		fmt.Printf("Name: %s Summary: %s WillRun: %d\n", tst.Name, tst.Summary, tst.TestResult)
+	for i, tst := range l {
+		if expected[i].Name != tst.Name {
+			t.Fatalf("Error in test ordering:\n Got %+v\nExpected %+v\n", tst, expected[i])
+		}
 	}
 }
 

--- a/local/testdata/cases/010_apps/001_test/test.sh
+++ b/local/testdata/cases/010_apps/001_test/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# SUMMARY: A test test!
+# LABELS:
+
+exit 0

--- a/local/types.go
+++ b/local/types.go
@@ -26,12 +26,11 @@ type Group struct {
 	PreTest   string
 	PostTest  string
 	Parent    *Group
-	Order     int
+	order     int
 	Path      string
 	Labels    map[string]bool
 	NotLabels map[string]bool
-	Tests     []*Test
-	Children  []*Group
+	Children  []TestContainer
 }
 
 // Test is a test
@@ -41,7 +40,7 @@ type Test struct {
 	Path      string
 	Command   exec.Cmd
 	Repeat    int
-	Order     int
+	order     int
 	Summary   string
 	Author    string
 	Labels    map[string]bool
@@ -92,3 +91,22 @@ type RunConfig struct {
 	NotLabels   map[string]bool
 	TestPattern string
 }
+
+// A TestContainer is a container that can hold one or more tests
+type TestContainer interface {
+	Order() int
+	List(config RunConfig) []Result
+	Run(config RunConfig) ([]Result, error)
+}
+
+// ByOrder implements the sort.Sorter interface for TestContainer
+type ByOrder []TestContainer
+
+// Len returns the length of the []TestContainer
+func (a ByOrder) Len() int { return len(a) }
+
+// Swap swaps two items in a []TestContainer
+func (a ByOrder) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// Less compares whether the order of i is less than that of j
+func (a ByOrder) Less(i, j int) bool { return a[i].Order() < a[j].Order() }


### PR DESCRIPTION
This PR introduces a TestContainer interface that can be sorted based on
Order. A group now contains a slice of TestContainer instead of a slice
of Groups and Tests. As TestContainer is sortable, a call to sort.Sort
is made before each List or Run command.

Fixes: #14

Signed-off-by: Dave Tucker <dt@docker.com>