### PR TITLE
Makefile: Only lint on test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ INEFFASSIGN:=$(shell command -v ineffassign 2> /dev/null)
 
 default: rtf
 
-rtf: $(DEPS) lint
+rtf: $(DEPS)
 	go build --ldflags "-X $(CMD_PKG).GitCommit=$(GIT_COMMIT) -X $(CMD_PKG).Version=$(VERSION)" -o $@
 
 .PHONY: lint
@@ -45,7 +45,7 @@ install-deps:
 	go get -u github.com/gordonklaus/ineffassign
 
 .PHONY: test
-test:
+test: rtf lint
 	@go test $(PKGS)
 
 .PHONY: install

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ jobs:
       - checkout
       - run: go get github.com/golang/lint/golint
       - run: go get github.com/gordonklaus/ineffassign
-      - run: cd $GOPATH/src/github.com/linuxkit/rtf && make
       - run: cd $GOPATH/src/github.com/linuxkit/rtf && make test
       - run: cd $GOPATH/src/github.com/linuxkit/rtf && make clean && make GOOS=darwin
       - run: cd $GOPATH/src/github.com/linuxkit/rtf && make clean && make GOOS=windows


### PR DESCRIPTION
This fixes issues with the homebrew formula failing to work due to
missing golint and ineffassign

Signed-off-by: Dave Tucker <dt@docker.com>