### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ GIT_COMMIT=$(shell git rev-list -1 HEAD)
 CMD_PKG=github.com/linuxkit/rtf/cmd
 PKGS:=$(shell go list ./... | grep -v vendor)
 
+GOOS?=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+GOARCH?=amd64
+ifneq ($(GOOS),linux)
+CROSS+=-e GOOS=$(GOOS)
+endif
+ifneq ($(GOARCH),amd64)
+CROSS+=-e GOARCH=$(GOARCH)
+endif
+
 DEPS=Makefile main.go
 DEPS+=$(wildcard cmd/*.go)
 DEPS+=$(wildcard local/*.go)
@@ -16,6 +25,18 @@ INEFFASSIGN:=$(shell command -v ineffassign 2> /dev/null)
 
 default: rtf
 
+# Build with docker
+GO_COMPILE=linuxkit/go-compile:7cac05c5588b3dd6a7f7bdb34fc1da90257394c7
+.PHONY: build-with-docker
+build-with-docker: tmp_rtf_bin.tar
+	tar xf $<
+	rm $<
+
+tmp_rtf_bin.tar: $(DEPS)
+	tar cf - . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/rtf --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o rtf > $@
+
+
+# Build local (default)
 rtf: $(DEPS)
 	go build --ldflags "-X $(CMD_PKG).GitCommit=$(GIT_COMMIT) -X $(CMD_PKG).Version=$(VERSION)" -o $@
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ choco install git
 The regression test framework allows running tests on a local host (or
 inside a VM) as well as against a suitably configured remote host.
 
+If you don't have the source code in your `GOPATH`, you may have to
+set the `RT_ROOT` environment variable to point to it.
+
 To run tests locally, simply execute the `rtf run` command. It will
 executed all the test cases in the supplied cases directory. This
 defaults to `./cases`

--- a/local/group.go
+++ b/local/group.go
@@ -119,7 +119,7 @@ func (g *Group) Init() error {
 
 // LabelString provides all labels in a comma separated list
 func (g *Group) LabelString() string {
-	return makeLabelString(g.Labels, g.NotLabels)
+	return makeLabelString(g.Labels, g.NotLabels, ", ")
 }
 
 // Name returns the name of the group
@@ -175,7 +175,7 @@ func (g *Group) Run(config RunConfig) ([]Result, error) {
 
 	if init {
 		config.Logger.Log(logger.LevelInfo, fmt.Sprintf("%s::ginit()", g.Name()))
-		res, err := executeScript(gfName, g.Path, "", g.LabelString(), []string{"init"}, config)
+		res, err := executeScript(gfName, g.Path, "", []string{"init"}, config)
 		if err != nil {
 			return results, err
 		}
@@ -194,7 +194,7 @@ func (g *Group) Run(config RunConfig) ([]Result, error) {
 
 	if init {
 		config.Logger.Log(logger.LevelInfo, fmt.Sprintf("%s::gdeinit()", g.Name()))
-		res, err := executeScript(gfName, g.Path, "", g.LabelString(), []string{"deinit"}, config)
+		res, err := executeScript(gfName, g.Path, "", []string{"deinit"}, config)
 		if err != nil {
 			return results, err
 		}

--- a/local/group.go
+++ b/local/group.go
@@ -132,7 +132,7 @@ func (g *Group) List(config RunConfig) []Result {
 	result := []Result{}
 	sort.Sort(ByOrder(g.Children))
 
-	if !WillRun(g.Labels, g.NotLabels, config) {
+	if !g.willRun(config) {
 		return []Result{{
 			TestResult: Skip,
 			Name:       g.Name(),
@@ -154,7 +154,7 @@ func (g *Group) Run(config RunConfig) ([]Result, error) {
 	var results []Result
 	sort.Sort(ByOrder(g.Children))
 
-	if !WillRun(g.Labels, g.NotLabels, config) {
+	if !g.willRun(config) {
 		return []Result{{TestResult: Skip,
 			Name:      g.Name(),
 			StartTime: time.Now(),
@@ -208,4 +208,17 @@ func (g *Group) Run(config RunConfig) ([]Result, error) {
 // Order returns the order of a group
 func (g *Group) Order() int {
 	return g.order
+}
+
+// willRun determines if tests from this group should be run based on labels and runtime config.
+func (g *Group) willRun(config RunConfig) bool {
+	if !CheckLabel(g.Labels, g.NotLabels, config) {
+		return false
+	}
+
+	if config.TestPattern == "" {
+		return true
+	}
+
+	return strings.HasPrefix(config.TestPattern, g.Name()) || strings.HasPrefix(g.Name(), config.TestPattern)
 }

--- a/local/labels.go
+++ b/local/labels.go
@@ -26,8 +26,8 @@ func ParseLabels(labels string) (map[string]bool, map[string]bool) {
 	return set, unSet
 }
 
-// WillRun determines if a group or test should run based on its labels and the RunConfig
-func WillRun(labels, notLabels map[string]bool, config RunConfig) bool {
+// CheckLabel determines if a group or test should run based on its labels and the RunConfig
+func CheckLabel(labels, notLabels map[string]bool, config RunConfig) bool {
 	// 1. If test has labels
 	if len(labels) > 0 {
 		// 2. Check that at least one test label is in the hostLabels
@@ -53,15 +53,6 @@ func WillRun(labels, notLabels map[string]bool, config RunConfig) bool {
 		if _, ok := labels[l]; ok {
 			return false
 		}
-	}
-	return true
-}
-
-// CheckPattern implements a test to see if a given name matches the provided pattern
-func CheckPattern(name, pattern string) bool {
-	// 1. Check that name begins with the TestPattern
-	if !strings.HasPrefix(name, pattern) {
-		return false
 	}
 	return true
 }

--- a/local/labels.go
+++ b/local/labels.go
@@ -57,7 +57,7 @@ func CheckLabel(labels, notLabels map[string]bool, config RunConfig) bool {
 	return true
 }
 
-func makeLabelString(labels map[string]bool, notLabels map[string]bool) string {
+func makeLabelString(labels map[string]bool, notLabels map[string]bool, sep string) string {
 	var l []string
 	for s := range notLabels {
 		l = append(l, fmt.Sprintf("!%s", s))
@@ -65,7 +65,7 @@ func makeLabelString(labels map[string]bool, notLabels map[string]bool) string {
 	for s := range labels {
 		l = append(l, s)
 	}
-	return strings.Join(l, ", ")
+	return strings.Join(l, sep)
 }
 
 func getNameAndOrder(path string) (int, string) {

--- a/local/labels_test.go
+++ b/local/labels_test.go
@@ -20,7 +20,7 @@ func TestParseLabels(t *testing.T) {
 	}
 }
 
-func TestWillRun(t *testing.T) {
+func TestCheckLabel(t *testing.T) {
 
 	darwin := map[string]bool{"darwin": true}
 	linux := map[string]bool{"linux": true}
@@ -29,27 +29,27 @@ func TestWillRun(t *testing.T) {
 	darwinUser := RunConfig{Labels: darwin}
 	linuxUser := RunConfig{Labels: linux}
 
-	if !WillRun(nil, nil, RunConfig{}) {
+	if !CheckLabel(nil, nil, RunConfig{}) {
 		t.Fatalf("Test with no labels on host with no labels doesn't run")
 	}
 
-	if !WillRun(nil, nil, darwinUser) {
+	if !CheckLabel(nil, nil, darwinUser) {
 		t.Fatalf("Test with no labels doesn't run!")
 	}
 
-	if !WillRun(darwin, nil, darwinUser) {
+	if !CheckLabel(darwin, nil, darwinUser) {
 		t.Fatalf("Darwin test doesn't run for darwin user")
 	}
 
-	if !WillRun(linux, nil, linuxUser) {
+	if !CheckLabel(linux, nil, linuxUser) {
 		t.Fatalf("Linux test doesn't run for linux user")
 	}
 
-	if WillRun(darwin, nil, linuxUser) {
+	if CheckLabel(darwin, nil, linuxUser) {
 		t.Fatalf("Darwin test runs for linuxUser")
 	}
 
-	if !WillRun(both, nil, darwinUser) {
+	if !CheckLabel(both, nil, darwinUser) {
 		t.Fatalf("Test on darwin/linux doesn't run for darwin user")
 	}
 }

--- a/local/script.go
+++ b/local/script.go
@@ -12,7 +12,7 @@ import (
 	"github.com/linuxkit/rtf/logger"
 )
 
-func executeScript(script, cwd, name, labels string, args []string, config RunConfig) (Result, error) {
+func executeScript(script, cwd, name string, args []string, config RunConfig) (Result, error) {
 	if name == "" {
 		name = "UNKNOWN"
 	}
@@ -50,6 +50,8 @@ func executeScript(script, cwd, name, labels string, args []string, config RunCo
 	if err != nil {
 		return Result{}, err
 	}
+
+	labels := makeLabelString(config.Labels, config.NotLabels, ":")
 
 	envPath := os.Getenv("PATH")
 	rtEnv := []string{

--- a/local/script.go
+++ b/local/script.go
@@ -36,13 +36,15 @@ func executeScript(script, cwd, name, labels string, args []string, config RunCo
 	}
 
 	osEnv := os.Environ()
-	goPath := os.Getenv("GOPATH")
-	libDir := filepath.Join(goPath, "src", "github.com", "linuxkit", "rtf", "lib", "lib.sh")
-	utilsDir := filepath.Join(goPath, "src", "github.com", "linuxkit", "rtf", "bin")
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return Result{}, err
+
+	rootDir := os.Getenv("RT_ROOT")
+	if rootDir == "" {
+		// Assume the source is in the GOPATH
+		goPath := os.Getenv("GOPATH")
+		rootDir = filepath.Join(goPath, "src", "github.com", "linuxkit", "rtf")
 	}
+	libDir := filepath.Join(rootDir, "lib", "lib.sh")
+	utilsDir := filepath.Join(rootDir, "bin")
 
 	projectDir, err := filepath.Abs(config.CaseDir)
 	if err != nil {
@@ -51,7 +53,7 @@ func executeScript(script, cwd, name, labels string, args []string, config RunCo
 
 	envPath := os.Getenv("PATH")
 	rtEnv := []string{
-		fmt.Sprintf("RT_ROOT=%s", currentDir),
+		fmt.Sprintf("RT_ROOT=%s", rootDir),
 		fmt.Sprintf("RT_UTILS=%s", utilsDir),
 		fmt.Sprintf("RT_PROJECT_ROOT=%s", projectDir),
 		fmt.Sprintf("RT_OS=%s", config.SystemInfo.OS),

--- a/local/test.go
+++ b/local/test.go
@@ -72,7 +72,7 @@ func (t *Test) Name() string {
 
 // LabelString returns all labels in a comma separated string
 func (t *Test) LabelString() string {
-	return makeLabelString(t.Labels, t.NotLabels)
+	return makeLabelString(t.Labels, t.NotLabels, ", ")
 }
 
 // List satisfies the TestContainer interface
@@ -128,7 +128,7 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 		defer config.Logger.Unregister(logFileName)
 
 		if t.Parent.PreTest != "" {
-			res, err := executeScript(t.Parent.PreTest, t.Path, name, t.LabelString(), []string{name}, config)
+			res, err := executeScript(t.Parent.PreTest, t.Path, name, []string{name}, config)
 			if res.TestResult != Pass {
 				return results, fmt.Errorf("Error running: %s. %s", t.Parent.PreTest, err.Error())
 			}
@@ -136,7 +136,7 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 		// Run the test
 		config.Logger.Log(logger.LevelInfo, fmt.Sprintf("Running Test %s in %s", name, t.Path))
 		tf := filepath.Join(t.Path, TestFile)
-		res, err := executeScript(tf, t.Path, name, t.LabelString(), nil, config)
+		res, err := executeScript(tf, t.Path, name, nil, config)
 		if err != nil {
 			return results, err
 		}
@@ -149,7 +149,7 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 			config.Logger.Log(logger.LevelCancel, fmt.Sprintf("%s %.2fs", res.Name, res.Duration.Seconds()))
 		}
 		if t.Parent.PostTest != "" {
-			res, err := executeScript(t.Parent.PostTest, t.Path, name, t.LabelString(), []string{name, fmt.Sprintf("%d", res.TestResult)}, config)
+			res, err := executeScript(t.Parent.PostTest, t.Path, name, []string{name, fmt.Sprintf("%d", res.TestResult)}, config)
 			if res.TestResult != Pass {
 				return results, fmt.Errorf("Error running: %s. %s", t.Parent.PreTest, err.Error())
 			}

--- a/local/test_test.go
+++ b/local/test_test.go
@@ -48,6 +48,6 @@ func TestTestPattern(t *testing.T) {
 		if tst.Name == "test.apps.basic.test" && tst.TestResult != Pass {
 			t.Fatal("test.apps.basic.test matches the TestPattern but is not going to run")
 		}
-		fmt.Printf("Name: %s Summary: %s WillRun: %d\n", tst.Name, tst.Summary, tst.TestResult)
+		fmt.Printf("Name: %s Summary: %s CheckLabel: %d\n", tst.Name, tst.Summary, tst.TestResult)
 	}
 }

--- a/sysinfo/sysinfo.go
+++ b/sysinfo/sysinfo.go
@@ -14,8 +14,15 @@ type SystemInfo struct {
 // platform specific information
 func GetSystemInfo() SystemInfo {
 	info := SystemInfo{
-		OS:   runtime.GOOS,
 		Arch: runtime.GOARCH,
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		info.OS = "osx"
+	case "windows":
+		info.OS = "win"
+	default:
+		info.OS = runtime.GOOS
 	}
 	return getPlatformSpecifics(info)
 }
@@ -28,11 +35,9 @@ func (s SystemInfo) List() []string {
 		s.Version,
 		s.Arch,
 	}
-	if s.OS == "darwin" {
-		l = append(l, "osx")
-	}
-	if s.OS == "windows" {
-		l = append(l, "win")
+	switch s.OS {
+	case "osx", "win":
+		l = append(l, runtime.GOOS)
 	}
 	return l
 }

--- a/sysinfo/sysinfo_darwin.go
+++ b/sysinfo/sysinfo_darwin.go
@@ -14,7 +14,7 @@ var osxVersionMap = map[string]string{
 }
 
 func getPlatformSpecifics(info SystemInfo) SystemInfo {
-	out, err := exec.Command("sw_vers-pver", "sw_vers", "-productVersion").Output()
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
 	if err != nil {
 		info.Name = "UNKNOWN"
 		info.Version = "UNKNOWN"


### PR DESCRIPTION
- Build using `docker`
- Make if work on Windows (use MSYS `bash.exe`)
- `RT_LABELS` is supposed to be a list of the run time labels and is supposed to be colon separated. Otherwise script functions like `rt_label_set()` don't work.
- `RT_ROOT` is supposed to point to the root of the `rtf` source tree to pick up the library and the utilities. It defaults to the go path but we now allow overriding it via a environment variable.
- `rtf` was executing the group `init` and `deinit` functions even if no tests in a group where selected. Fix it.
- Fix version on macOS
