### PR TITLE
sysinfo: Fix OSX version parsing

### DIFF
--- a/sysinfo/sysinfo_darwin.go
+++ b/sysinfo/sysinfo_darwin.go
@@ -11,6 +11,7 @@ var osxVersionMap = map[string]string{
 	"10.10": "OS X Yosemite",
 	"10.11": "OS X El Capitan",
 	"10.12": "macOS Sierra",
+	"10.13": "macOS High Sierra",
 }
 
 func getPlatformSpecifics(info SystemInfo) SystemInfo {
@@ -21,10 +22,15 @@ func getPlatformSpecifics(info SystemInfo) SystemInfo {
 		return info
 	}
 	info.Version = strings.TrimSpace(string(out))
-	var ok bool
-	info.Name, ok = osxVersionMap[info.Version]
-	if !ok {
-		info.Version = "UNKNOWN"
-	}
+	info.Name = resolveNameFromVersion(info.Version)
 	return info
+}
+
+func resolveNameFromVersion(version string) string {
+	for k, v := range osxVersionMap {
+		if strings.HasPrefix(version, k) {
+			return v
+		}
+	}
+	return "UNKNOWN"
 }

--- a/sysinfo/sysinfo_darwin_test.go
+++ b/sysinfo/sysinfo_darwin_test.go
@@ -1,0 +1,20 @@
+package sysinfo
+
+import "testing"
+
+func TestResolveNameFromVersion(t *testing.T) {
+	for _, tt := range []struct {
+		in  string
+		out string
+	}{
+		{"10.9", "OS X Mavericks"},
+		{"10.10.3", "OS X Yosemite"},
+		{"10.11.1", "OS X El Capitan"},
+		{"10.12.6", "macOS Sierra"},
+		{"10.13", "macOS High Sierra"},
+	} {
+		if name := resolveNameFromVersion(tt.in); name != tt.out {
+			t.Errorf("resolveNameFromVersion %s\nExpected: %s\nGot: %s\n", tt.in, tt.out, name)
+		}
+	}
+}


### PR DESCRIPTION
Before this commit, patch versions of OSX were detected as UNKNOWN as we
were looking for an exact match. This changes the behaviour to check for
a prefix and adds a test to catch future regressions.
I also added High Sierra since 10.13 is now in the wild.

Signed-off-by: Dave Tucker <dt@docker.com>