### PR TITLE
Dockerfile: Add Dockerfile for shipping binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.9.1
+
+ARG LDFLAGS
+WORKDIR /go/src/github.com/linuxkit/rtf
+COPY . /go/src/github.com/linuxkit/rtf
+
+RUN CGO_ENABLED=0 go install -v -ldflags="$LDFLAGS" && \
+	GOOS=darwin GOARCH=amd64 go install -v -ldflags="$LDFLAGS" && \
+	GOOS=windows GOARCH=amd64 go install -v -ldflags="$LDFLAGS" && \
+	GOOS=linux GOARCH=arm64 go install -v -ldflags="$LDFLAGS"
+FROM scratch
+COPY --from=0 /go/bin/rtf /rtf-Linux-x86_64
+COPY --from=0 /go/bin/darwin_amd64/rtf /rtf-Darwin-x86_64
+COPY --from=0 /go/bin/windows_amd64/rtf.exe /rtf-Windows-x86_64
+COPY --from=0 /go/bin/linux_arm64/rtf /rtf-Linux-aarch64


### PR DESCRIPTION
This commit adds a Dockerfile and docker-image, and push targets to the
Makefile. This allows a Docker image to be used for distributing
binaries which is simpler than packaging for every environment.
Binaries can be extracted as follows:

```
docker pull linuxkit/rtf:latest
id=$(docker create linuxkit/rtf:latest true) &&
docker cp $id:/rtf-$(uname -s)-$(uname -m) rtf &&
(docker rm $id > /dev/null)
```

Signed-off-by: Dave Tucker <dt@docker.com>