### PR TITLE
Fix command descriptions

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -24,10 +24,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
 var infoCmd = &cobra.Command{
 	Use:   "info",
-	Short: "A brief description of your command",
+	Short: "Print test cases and their descriptions",
 	RunE:  info,
 }
 
@@ -36,13 +35,9 @@ func init() {
 }
 
 func info(cmd *cobra.Command, args []string) error {
-	//blue := color.New(color.FgBlue).SprintFunc()
-
 	if len(args) > 1 {
 		return fmt.Errorf("Expected only one test pattern")
 	}
-
-	//a := strings.Join(args, "")
 
 	systemInfo := sysinfo.GetSystemInfo()
 	l, nl := local.ParseLabels(labels)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -20,7 +20,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/linuxkit/rtf/local"
-	"github.com/linuxkit/rtf/sysinfo"
 	"github.com/spf13/cobra"
 )
 
@@ -34,34 +33,15 @@ func init() {
 	RootCmd.AddCommand(infoCmd)
 }
 
-func info(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 {
-		return fmt.Errorf("Expected only one test pattern")
-	}
-
-	systemInfo := sysinfo.GetSystemInfo()
-	l, nl := local.ParseLabels(labels)
-	for _, v := range systemInfo.List() {
-		if _, ok := l[v]; !ok {
-			l[v] = true
-		}
-	}
-	p, err := local.NewProject(caseDir)
+func info(_ *cobra.Command, _ []string) error {
+	config := local.NewRunConfig(labels, "")
+	p, err := local.InitNewProject(caseDir)
 	if err != nil {
-		return err
-	}
-
-	if err := p.Init(); err != nil {
 		return err
 	}
 
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
-
-	config := local.RunConfig{
-		Labels:    l,
-		NotLabels: nl,
-	}
 
 	lst := p.List(config)
 	fmt.Fprintf(w, "NAME\tDESCRIPTION\n")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,7 +29,7 @@ import (
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "A brief description of your command",
+	Short: "List test cases",
 	RunE:  list,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,11 +24,7 @@ import (
 
 var (
 	caseDir    string
-	resultDir  string
 	labels     string
-	envVars    []string
-	extra      bool
-	loggerAddr string
 	verbose    int
 )
 
@@ -52,13 +48,10 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().StringVarP(&caseDir, "casedir", "c", "cases", "Directory containing cases")
-	RootCmd.PersistentFlags().StringVarP(&resultDir, "resultdir", "r", "_results", "Directory to place results in")
-	RootCmd.PersistentFlags().StringVarP(&labels, "labels", "l", "", "Labels to apply (comma separated)")
-	RootCmd.PersistentFlags().StringSliceVarP(&envVars, "envVars", "e", []string{}, "Add a environment variable (multiple uses allowed)")
-	RootCmd.PersistentFlags().BoolVarP(&extra, "extra", "x", false, "Add extra debug info to log files")
-	RootCmd.PersistentFlags().StringVar(&loggerAddr, "logger", "", "<host>:<port> of a socket to log stdout to")
-	RootCmd.PersistentFlags().CountVarP(&verbose, "verbose", "v", "Increase verbosity level")
+	flags := RootCmd.PersistentFlags()
+	flags.StringVarP(&caseDir, "casedir", "c", "cases", "Directory containing cases")
+	flags.StringVarP(&labels, "labels", "l", "", "Labels to apply (comma separated)")
+	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity level")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var (
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:           os.Args[0],
-	Short:         "Run or provide information about local regression tests",
+	Short:         "Regression testing framework",
 	SilenceErrors: true,
 	SilenceUsage:  true,
 }
@@ -52,9 +52,6 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports Persistent Flags, which, if defined here,
-	// will be global for your application.
 	RootCmd.PersistentFlags().StringVarP(&caseDir, "casedir", "c", "cases", "Directory containing cases")
 	RootCmd.PersistentFlags().StringVarP(&resultDir, "resultdir", "r", "_results", "Directory to place results in")
 	RootCmd.PersistentFlags().StringVarP(&labels, "labels", "l", "", "Labels to apply (comma separated)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	caseDir    string
-	labels     string
-	verbose    int
+	caseDir string
+	labels  string
+	verbose int
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -61,10 +61,9 @@ var (
 	}
 )
 
-// listCmd represents the list command
 var runCmd = &cobra.Command{
 	Use:   "run [test pattern]",
-	Short: "A brief description of your command",
+	Short: "Run test cases",
 	RunE:  run,
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -61,6 +61,11 @@ var (
 	}
 )
 
+var (
+	resultDir  string
+	extra      bool
+)
+
 var runCmd = &cobra.Command{
 	Use:   "run [test pattern]",
 	Short: "Run test cases",
@@ -68,6 +73,9 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
+	flags := runCmd.LocalFlags()
+	flags.StringVarP(&resultDir, "resultdir", "r", "_results", "Directory to place results in")
+	flags.BoolVarP(&extra, "extra", "x", false, "Add extra debug info to log files")
 	RootCmd.AddCommand(runCmd)
 }
 

--- a/local/group.go
+++ b/local/group.go
@@ -26,6 +26,15 @@ func NewProject(path string) (*Group, error) {
 	return g, nil
 }
 
+// InitNewProject creates a new Group, and calls Init() on it
+func InitNewProject(path string) (*Group, error) {
+	group, err := NewProject(path)
+	if err != nil {
+		return group, err
+	}
+	return group, group.Init()
+}
+
 // NewGroup creates a new Group with the given parent and path
 func NewGroup(parent *Group, path string) (*Group, error) {
 	g := &Group{Parent: parent, Path: path, PreTest: parent.PreTest, PostTest: parent.PostTest}


### PR DESCRIPTION
Fixes command short descriptions that were left as the default value.
Moves flags only used by run to the run command
Removes unused flags
Removes some duplication between commands