### PR TITLE
local: Fix panic when no pattern is supplied

### DIFF
--- a/local/labels.go
+++ b/local/labels.go
@@ -105,5 +105,8 @@ func ValidatePattern(args []string) (string, error) {
 	if len(args) > 1 {
 		return "", fmt.Errorf("Expected only one test pattern")
 	}
+	if len(args) == 0 {
+		return "", nil
+	}
 	return args[0], nil
 }


### PR DESCRIPTION
If len(args) == 0 go would panic.
Return an empty string in this case.

Signed-off-by: Dave Tucker <dt@docker.com>