### PR TITLE
flags: make `-x` work

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the test are written as shell scripts. The library code is in the `rt`
 directory and some common utilities and helper programs are contained in
 the `utils` directory.
 
--   `rtf` - a local test runner
+- `rtf` - a local test runner
 
 For more details, see the documentation in `./docs/USER_GUIDE.md`.
 
@@ -66,14 +66,15 @@ contents as `TESTS.log`.
 
 If you prefer a bit more information in the log files use:
 ```
-rtf -x run
+rtf -v run -x
 ```
 
-This executes the tests with `-x` and thus logs all commands executed.
+This executes the tests with `-x`, logging all commands executed to `stderr`;
+and with `-v`, causing `stderr` to be displayed to the console.
 
 For a CI system, where the output is displayed on a web page use:
 ```
-rtf -x -vvv run
+rtf -vvv run -x
 ```
 
 This prints the same information logged to the log file to the console.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,7 +74,7 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	flags := runCmd.LocalFlags()
+	flags := runCmd.Flags()
 	flags.StringVarP(&resultDir, "resultdir", "r", "_results", "Directory to place results in")
 	flags.BoolVarP(&extra, "extra", "x", false, "Add extra debug info to log files")
 	RootCmd.AddCommand(runCmd)


### PR DESCRIPTION
Adding to `LocalFlags()` appears to update the help text, but not actually make the new flag work. Using `Flags()` seems to fix that.
