### PR TITLE
Add support for writing tests in powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,27 @@ make test
 
 ## Prerequisites
 
-On a Mac and Linux, this should pretty much just work out of the box.
+On a Mac and Linux, this should pretty much just work out of the
+box. The tests are written in `sh` and expect it to be installed in
+`/bin/sh`. Some optional utilities (see [`./bin`](./bin)) are written
+in `python` and if your tests use them, you need to have python
+installed.
 
-On Windows, you need to have form of `bash`.
-The tests must be run from a `bash` shell and `bash.exe` must be
-in your path. The simplest way is to install via
-[chocolatey](https://chocolatey.org/)
+On Windows, it depends on how your tests are written. If they are
+written as `powershell` scripts, `rtf` should just work. If they are
+written as shell scripts, you need to have the MSYS2 variant of `bash`
+installed and `bash.exe` must be in your path. The simplest way to
+install it is to install `git` via
+[chocolatey](https://chocolatey.org/). Note, neither `bash` from WSL
+nor cygwin is currently supported.
 
 ```
 choco install git
+```
+
+If your tests use the optional utilities in, you also need to install `python`:
+```
+choco install python
 ```
 
 ## Quickstart

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -33,7 +33,7 @@ tests are run.  The primary tool for this are _labels_.
 A test may define that a specific label "foobar" must be present for
 it to be run or, by prefixing the label name with a '!', that the test
 should not be run if a label is defined. The labels are defined with
-`test.sh` (see below).
+`test.sh` or `test.ps1` (see below).
 
 The regression test framework is completely agnostic to which labels
 are used for a given set of test cases, though it defines a number of
@@ -90,12 +90,13 @@ can be use to indicate that the test was cancelled (for whatever
 reason).  Each test must be located in its own sub-directory (together
 with any files it may require).
 
-Currently, a test is a simple shell script called `test.sh`. In the
-future we will also support Python and Powershell (for Windows only
-tests).
+Currently, a test is a simple shell script called `test.sh`. On
+Windows, tests may also be written as Powershell scripts and the test
+script should be called `test.ps1`.
 
-There is a template `test.sh` in `./etc/templates/test.sh` which can be
-used for writing tests. It contains a number of special comments
+There are template [`test.sh`](../etc/templates/test.sh) and
+[`test.ps1`](../etc/templates/test.sh) files which can be used for
+writing tests. A test script contains a number of special comments
 (`SUMMARY`, `LABELS`, `REPEAT`, and, `AUTHOR`) which are used by the
 regression test framework. The `SUMMARY` line should contain a *short*
 summary of what the test does. The `LABEL` is a (optional) list of
@@ -126,7 +127,8 @@ environment variables into a test script:
 
 - `RT_ROOT`: Points to the root of the test framework.
 
-- `RT_LIB`: Points to the common shell library found in `rt/lib/lib.sh`
+- `RT_LIB`: Points to the common shell library found in
+  [`lib.sh`](../lib/lib.sh) or [`lib.ps1`](../lib/lib.ps1)
 
 - `RT_UTILS`: Points to the directory where the helper applications
   are available
@@ -183,28 +185,31 @@ which may be useful when writing tests (the environment variable
 
 Any directory containing sub-directories with tests under the
 top-level project directory forms a test group.  The execution of a
-group can be customised by defining a `group.sh` file inside the group
-directory.  Like with tests, the `group.sh` may provide a `SUMMARY`
-and a set of `LABELS`.
+group can be customised by defining a `group.sh` or `group.ps1` file
+inside the group directory.  Like with tests, the group script may
+provide a `SUMMARY` and a set of `LABELS`.
 
-If a group contains a `group.sh` file, it is executed with the `init`
-argument before the first test if the groups is executed, and with the
-`deinit` argument after the last test of the group was executed.  Test
-writers can thus place group specific initialisation code into
-`group.sh`. `group.sh` is executed with the same environment variables
-set as `test.sh` scripts.
+If a group directory contains a `group.sh`/`group.ps1` file, it is
+executed with the `init` argument before the first test of the group
+is executed, and with the `deinit` argument after the last test of the
+group was executed.  Test writers can thus place group specific
+initialisation code into `group.sh`/`group.ps1`. The group script is
+executed with the same environment variables set as `test.sh` scripts.
 
-There is a template `group.sh` file in `./etc/templates/group.sh`.
+There are template [`group.sh`](../etc/templates/group.sh) and
+[`group.ps1`](../etc/templates/group.ps1) files.
 
-The top-level `group.sh` should also create a `VERSION.txt` file in
-`RT_RESULTS`, containing some form of version information.  If the
-tests are run against a local build, this could be the git sha value,
-or when run as part of CI the version of the build being tested etc.
+The top-level `group.sh`/`group.ps1` should also create a
+`VERSION.txt` file in `RT_RESULTS`, containing some form of version
+information.  If the tests are run against a local build, this could
+be the git sha value, or when run as part of CI the version of the
+build being tested etc.
 
 In addition, the top-level group may also contain two optional
-scripts, `pre-test.sh` and `post-test.sh`, which are executed before
-and after each test is run.  Both get the test name as first argument
-and `post-test.sh` gets passed the test result as the second argument.
-The idea is that these scripts may be used to collect additional
-logging or collect debug information if a test fails.  They can store
-the per test information in files prefixed with `"${RT_RESULT}/$1"`.
+scripts, `pre-test.sh` and `post-test.sh` (or Powershell equivalent),
+which are executed before and after each test is run.  Both get the
+test name as first argument and `post-test.sh` gets passed the test
+result as the second argument.  The idea is that these scripts may be
+used to collect additional logging or collect debug information if a
+test fails.  They can store the per test information in files prefixed
+with `"${RT_RESULT}/$1"`.

--- a/etc/templates/group.ps1
+++ b/etc/templates/group.ps1
@@ -1,0 +1,31 @@
+# SUMMARY: 
+# LABELS:
+# For the top level group.ps1 also specify a 'NAME:' comment
+
+# Print each line executed
+Set-PSDebug -Trace 2
+
+# Source libraries. Uncomment if needed/defined
+#. $env:RT_LIB
+
+# returns from functions in posh seem to contain all the output, so we
+# use a global variable to get the return value.
+$res = 0
+
+function GroupInit([REF]$res) {
+    # Group initialisation code goes here
+    $res.Value = 0
+}
+
+function GroupDeinit([REF]$res) {
+    # Group de-initialisation code goes here
+    $res.Value = 0
+}
+
+$CMD=$args[0]
+Switch ($CMD) {
+    'init'    { GroupInit $res }
+    'deinit'  { GroupDeinit $res }
+}
+
+exit $res

--- a/etc/templates/group.sh
+++ b/etc/templates/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: Docker for Mac and Windows regression tests
 # LABELS:
 # For the top level group.sh also specify a 'NAME:' comment

--- a/etc/templates/test.ps1
+++ b/etc/templates/test.ps1
@@ -1,0 +1,14 @@
+# SUMMARY:
+# LABELS:
+# REPEAT:
+# AUTHOR:
+
+# Print each line executed
+Set-PSDebug -Trace 2
+
+# Source libraries. Uncomment if needed/defined
+#. $env:RT_LIB
+
+# Test code goes here
+
+exit 0

--- a/etc/templates/test.sh
+++ b/etc/templates/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY:
 # LABELS:
 # REPEAT:

--- a/lib/lib.ps1
+++ b/lib/lib.ps1
@@ -1,0 +1,8 @@
+##
+## A library of powershell functions
+##
+
+# Special return code to indicate that a test was cancelled
+RT_TEST_CANCEL=253
+
+# TODO: needs expanding

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 ##
 ## A library of shell functions
 ##

--- a/local/group.go
+++ b/local/group.go
@@ -37,7 +37,7 @@ func InitNewProject(path string) (*Group, error) {
 
 // NewGroup creates a new Group with the given parent and path
 func NewGroup(parent *Group, path string) (*Group, error) {
-	g := &Group{Parent: parent, Path: path, PreTest: parent.PreTest, PostTest: parent.PostTest}
+	g := &Group{Parent: parent, Path: path, PreTestPath: parent.PreTestPath, PostTestPath: parent.PostTestPath}
 	if err := g.Init(); err != nil {
 		return nil, err
 	}
@@ -84,11 +84,11 @@ func (g *Group) Init() error {
 		pre := filepath.Join(g.Path, PreTestFile)
 		post := filepath.Join(g.Path, PostTestFile)
 		if _, err := os.Stat(pre); err == nil {
-			g.PreTest = pre
+			g.PreTestPath = pre
 		}
 
 		if _, err := os.Stat(post); err == nil {
-			g.PostTest = post
+			g.PostTestPath = post
 		}
 
 	} else {

--- a/local/group.go
+++ b/local/group.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -53,7 +52,7 @@ func IsGroup(path string) bool {
 	}
 
 	for _, file := range files {
-		if file.Name() == GroupFile {
+		if file.Name() == GroupFileName+".sh" || file.Name() == GroupFileName+".ps1" {
 			return true
 		}
 		if file.IsDir() {
@@ -65,10 +64,7 @@ func IsGroup(path string) bool {
 
 // Init is the group initialization function and should be called immediately after a group has been created
 func (g *Group) Init() error {
-	gf := filepath.Join(g.Path, GroupFile)
-	if _, err := os.Stat(gf); err == nil {
-		g.GroupFilePath = gf
-	}
+	g.GroupFilePath, _ = checkScript(g.Path, GroupFileName)
 
 	tags, err := ParseTags(g.GroupFilePath)
 	if err != nil {
@@ -85,16 +81,8 @@ func (g *Group) Init() error {
 
 	if g.Parent == nil {
 		// top of tree
-		pre := filepath.Join(g.Path, PreTestFile)
-		post := filepath.Join(g.Path, PostTestFile)
-		if _, err := os.Stat(pre); err == nil {
-			g.PreTestPath = pre
-		}
-
-		if _, err := os.Stat(post); err == nil {
-			g.PostTestPath = post
-		}
-
+		g.PreTestPath, _ = checkScript(g.Path, PreTestFileName)
+		g.PostTestPath, _ = checkScript(g.Path, PostTestFileName)
 	} else {
 		g.Tags.Name = fmt.Sprintf("%s.%s", g.Parent.Name(), name)
 	}

--- a/local/script_test.go
+++ b/local/script_test.go
@@ -1,0 +1,36 @@
+package local
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetEnv(t *testing.T) {
+
+	env := []string{"FOO=foo", "BAR=bar"}
+
+	setEnv(&env, "FOO", "baz")
+	exp := []string{"FOO=baz", "BAR=bar"}
+	if !reflect.DeepEqual(env, exp) {
+		t.Fatalf("Overwriting an existing variable failed: %v != %v", env, exp)
+	}
+
+	setEnv(&env, "BAZ", "baz")
+	exp = []string{"FOO=baz", "BAR=bar", "BAZ=baz"}
+	if !reflect.DeepEqual(env, exp) {
+		t.Fatalf("Adding an existing variable failed: %v != %v", env, exp)
+	}
+
+	setEnv(&env, "BAZ", "foo")
+	exp = []string{"FOO=baz", "BAR=bar", "BAZ=foo"}
+	if !reflect.DeepEqual(env, exp) {
+		t.Fatalf("Overwriting an added variable failed: %v != %v", env, exp)
+	}
+
+	env = []string{"FOO_foo", "BAR=bar"}
+	setEnv(&env, "FOO", "foo")
+	exp = []string{"FOO_foo", "BAR=bar", "FOO=foo"}
+	if !reflect.DeepEqual(env, exp) {
+		t.Fatalf("Adding a variable to a malformed environment failed: %v != %v", env, exp)
+	}
+}

--- a/local/test.go
+++ b/local/test.go
@@ -2,8 +2,6 @@ package local
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,23 +20,15 @@ func NewTest(group *Group, path string) (*Test, error) {
 
 // IsTest determines if a path contains a test or not
 func IsTest(path string) bool {
-	files, err := ioutil.ReadDir(path)
-	if err != nil {
-		log.Fatal(err)
+	if _, err := checkScript(path, TestFileName); err != nil {
 		return false
 	}
-
-	for _, file := range files {
-		if file.Name() == TestFile {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 // Init initializes a test and should be run immmediately after NewTest
 func (t *Test) Init() error {
-	t.TestFilePath = filepath.Join(t.Path, TestFile)
+	t.TestFilePath, _ = checkScript(t.Path, TestFileName)
 	tags, err := ParseTags(t.TestFilePath)
 	if err != nil {
 		return err

--- a/local/test.go
+++ b/local/test.go
@@ -38,8 +38,8 @@ func IsTest(path string) bool {
 
 // Init initializes a test and should be run immmediately after NewTest
 func (t *Test) Init() error {
-	tf := filepath.Join(t.Path, TestFile)
-	tags, err := ParseTags(tf)
+	t.TestFilePath = filepath.Join(t.Path, TestFile)
+	tags, err := ParseTags(t.TestFilePath)
 	if err != nil {
 		return err
 	}
@@ -135,8 +135,7 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 		}
 		// Run the test
 		config.Logger.Log(logger.LevelInfo, fmt.Sprintf("Running Test %s in %s", name, t.Path))
-		tf := filepath.Join(t.Path, TestFile)
-		res, err := executeScript(tf, t.Path, name, nil, config)
+		res, err := executeScript(t.TestFilePath, t.Path, name, nil, config)
 		if err != nil {
 			return results, err
 		}

--- a/local/test.go
+++ b/local/test.go
@@ -127,10 +127,10 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 		config.Logger.Register(logFileName, testLogger)
 		defer config.Logger.Unregister(logFileName)
 
-		if t.Parent.PreTest != "" {
-			res, err := executeScript(t.Parent.PreTest, t.Path, name, []string{name}, config)
+		if t.Parent.PreTestPath != "" {
+			res, err := executeScript(t.Parent.PreTestPath, t.Path, name, []string{name}, config)
 			if res.TestResult != Pass {
-				return results, fmt.Errorf("Error running: %s. %s", t.Parent.PreTest, err.Error())
+				return results, fmt.Errorf("Error running: %s. %s", t.Parent.PreTestPath, err.Error())
 			}
 		}
 		// Run the test
@@ -148,10 +148,10 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 		case Cancel:
 			config.Logger.Log(logger.LevelCancel, fmt.Sprintf("%s %.2fs", res.Name, res.Duration.Seconds()))
 		}
-		if t.Parent.PostTest != "" {
-			res, err := executeScript(t.Parent.PostTest, t.Path, name, []string{name, fmt.Sprintf("%d", res.TestResult)}, config)
+		if t.Parent.PostTestPath != "" {
+			res, err := executeScript(t.Parent.PostTestPath, t.Path, name, []string{name, fmt.Sprintf("%d", res.TestResult)}, config)
 			if res.TestResult != Pass {
-				return results, fmt.Errorf("Error running: %s. %s", t.Parent.PostTest, err.Error())
+				return results, fmt.Errorf("Error running: %s. %s", t.Parent.PostTestPath, err.Error())
 			}
 		}
 		results = append(results, res)

--- a/local/test_test.go
+++ b/local/test_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -14,15 +15,36 @@ func TestFindingTests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := []Result{
-		{Name: "test.osx"},
-		{Name: "test.win"},
-		{Name: "test.apps.test"},
-		{Name: "test.apps.basic.test"},
-		{Name: "test.apps.advanced.test"},
+	var expected []Result
+	switch runtime.GOOS {
+	case "darwin":
+		expected = []Result{
+			{Name: "test.osx.test"},
+			{Name: "test.win"},
+			{Name: "test.apps.test"},
+			{Name: "test.apps.basic.test"},
+			{Name: "test.apps.advanced.test"},
+		}
+	case "windows":
+		expected = []Result{
+			{Name: "test.osx"},
+			{Name: "test.win.test"},
+			{Name: "test.win.ps1.test"},
+			{Name: "test.apps.test"},
+			{Name: "test.apps.basic.test"},
+			{Name: "test.apps.advanced.test"},
+		}
+	default:
+		expected = []Result{
+			{Name: "test.osx"},
+			{Name: "test.win"},
+			{Name: "test.apps.test"},
+			{Name: "test.apps.basic.test"},
+			{Name: "test.apps.advanced.test"},
+		}
 	}
 
-	config := RunConfig{}
+	config := NewRunConfig("", "")
 	l := p.List(config)
 	for i, tst := range l {
 		if expected[i].Name != tst.Name {

--- a/local/testdata/bad_test.sh
+++ b/local/testdata/bad_test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # AUTHOR: Dave Tucker <dt@docker.com>
 # AUTHOR: Rolf Neugebauer <rofl.neugebauer@docker.com>
 # SUMMARY: A Test

--- a/local/testdata/cases/000_osx/010_test/test.sh
+++ b/local/testdata/cases/000_osx/010_test/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: A test test!
 # LABELS:
 

--- a/local/testdata/cases/000_osx/group.sh
+++ b/local/testdata/cases/000_osx/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: OS X tests
 # LABELS: osx
 

--- a/local/testdata/cases/000_win/010_test/test.sh
+++ b/local/testdata/cases/000_win/010_test/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: A test test!
 # LABELS:
 

--- a/local/testdata/cases/000_win/020_ps1/010_test/test.ps1
+++ b/local/testdata/cases/000_win/020_ps1/010_test/test.ps1
@@ -1,0 +1,4 @@
+# SUMMARY: A test test!
+# LABELS:
+
+Exit 0

--- a/local/testdata/cases/000_win/020_ps1/group.ps1
+++ b/local/testdata/cases/000_win/020_ps1/group.ps1
@@ -1,0 +1,4 @@
+# SUMMARY: Windows Powershell test
+# LABELS: win
+
+Write-Output "win tests"

--- a/local/testdata/cases/000_win/group.sh
+++ b/local/testdata/cases/000_win/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: Windows specific tests
 # LABELS: win
 

--- a/local/testdata/cases/010_apps/001_test/test.sh
+++ b/local/testdata/cases/010_apps/001_test/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: A test test!
 # LABELS:
 

--- a/local/testdata/cases/010_apps/010_basic/010_test/test.sh
+++ b/local/testdata/cases/010_apps/010_basic/010_test/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: A test test!
 # LABELS:
 

--- a/local/testdata/cases/010_apps/010_basic/group.sh
+++ b/local/testdata/cases/010_apps/010_basic/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: Test
 # NAME: basic
 # LABELS:

--- a/local/testdata/cases/010_apps/020_advanced/010_test/test.sh
+++ b/local/testdata/cases/010_apps/020_advanced/010_test/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: A test test!
 # LABELS:
 

--- a/local/testdata/cases/010_apps/020_advanced/group.sh
+++ b/local/testdata/cases/010_apps/020_advanced/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: Test
 # NAME: advanced
 # LABELS:

--- a/local/testdata/cases/010_apps/group.sh
+++ b/local/testdata/cases/010_apps/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: Test
 # NAME: apps
 # LABELS:

--- a/local/testdata/cases/group.sh
+++ b/local/testdata/cases/group.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SUMMARY: Test
 # NAME: test
 # LABELS:

--- a/local/testdata/cases/post-test.sh
+++ b/local/testdata/cases/post-test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Post test hook
 
 echo "Post test hook"

--- a/local/testdata/test.sh
+++ b/local/testdata/test.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # AUTHOR: Dave Tucker <dt@docker.com>
 # AUTHOR: Rolf Neugebauer <rolf.neugebauer@docker.com>
 # SUMMARY: A Test

--- a/local/types.go
+++ b/local/types.go
@@ -22,15 +22,15 @@ const (
 
 // Group is a group of tests and other groups
 type Group struct {
-	Tags      *Tags
-	PreTest   string
-	PostTest  string
-	Parent    *Group
-	order     int
-	Path      string
-	Labels    map[string]bool
-	NotLabels map[string]bool
-	Children  []TestContainer
+	Tags         *Tags
+	PreTestPath  string
+	PostTestPath string
+	Parent       *Group
+	order        int
+	Path         string
+	Labels       map[string]bool
+	NotLabels    map[string]bool
+	Children     []TestContainer
 }
 
 // Test is a test

--- a/local/types.go
+++ b/local/types.go
@@ -22,15 +22,16 @@ const (
 
 // Group is a group of tests and other groups
 type Group struct {
-	Tags         *Tags
-	PreTestPath  string
-	PostTestPath string
-	Parent       *Group
-	order        int
-	Path         string
-	Labels       map[string]bool
-	NotLabels    map[string]bool
-	Children     []TestContainer
+	Parent        *Group
+	Tags          *Tags
+	Path          string
+	GroupFilePath string
+	PreTestPath   string
+	PostTestPath  string
+	order         int
+	Labels        map[string]bool
+	NotLabels     map[string]bool
+	Children      []TestContainer
 }
 
 // Test is a test

--- a/local/types.go
+++ b/local/types.go
@@ -36,16 +36,17 @@ type Group struct {
 
 // Test is a test
 type Test struct {
-	Parent    *Group
-	Tags      *Tags
-	Path      string
-	Command   exec.Cmd
-	Repeat    int
-	order     int
-	Summary   string
-	Author    string
-	Labels    map[string]bool
-	NotLabels map[string]bool
+	Parent       *Group
+	Tags         *Tags
+	Path         string
+	TestFilePath string
+	Command      exec.Cmd
+	Repeat       int
+	order        int
+	Summary      string
+	Author       string
+	Labels       map[string]bool
+	NotLabels    map[string]bool
 }
 
 // TestResult is the result of a test run

--- a/local/types.go
+++ b/local/types.go
@@ -1,7 +1,10 @@
 package local
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 
 	"github.com/linuxkit/rtf/logger"
 	"github.com/linuxkit/rtf/sysinfo"
@@ -10,15 +13,32 @@ import (
 )
 
 const (
-	// GroupFile is the name of the group script
-	GroupFile = "group.sh"
-	// PreTestFile is the name of a pre-test script
-	PreTestFile = "pre-test.sh"
-	// PostTestFile is the name of a ppst-test script
-	PostTestFile = "post-test.sh"
-	// TestFile is the name of a test script
-	TestFile = "test.sh"
+	// GroupFileName is the name of the group script (without the extension)
+	GroupFileName = "group"
+	// PreTestFileName is the name of a pre-test script (without the extension)
+	PreTestFileName = "pre-test"
+	// PostTestFileName is the name of a post-test script (without the extension)
+	PostTestFileName = "post-test"
+	// TestFileName is the name of a test script (without the extension)
+	TestFileName = "test"
 )
+
+// checkScript checks if a script with 'name' exists in 'path'
+func checkScript(path, name string) (string, error) {
+	// On Windows, powershell scripts take precedence.
+	if runtime.GOOS == "windows" {
+		f := filepath.Join(path, name+".ps1")
+		if _, err := os.Stat(f); err == nil {
+			return f, nil
+		}
+	}
+
+	f := filepath.Join(path, name+".sh")
+	if _, err := os.Stat(f); err != nil {
+		return "", err
+	}
+	return f, nil
+}
 
 // Group is a group of tests and other groups
 type Group struct {


### PR DESCRIPTION
This PR adds support for writing tests in powershell (on windows).

The first 5 commits contain some minor cleanup/simplifications which make it easier to re-use code between shell and powershell tests. The next two commits contain the core of the new functionality
 and the remaining commits add tests and documentation.

resolves #36