### PR TITLE
Preserve full precision in nanoseconds part of log timestamp

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -182,7 +182,8 @@ func (c consoleLogFormatter) Format(timestamp time.Time, level LogLevel, msg str
 	case LevelPass, LevelFail, LevelSkip, LevelSummary, LevelCancel:
 		s = fmt.Sprintf("%s %s\n", l, msg)
 	default:
-		s = fmt.Sprintf("%s %s: %s\n", l, timestamp.Format(time.RFC3339Nano), msg)
+		// Format is time.RFC3339Nano but with trailing zeroes preserved on the nanosecond field (s/9/0/)
+		s = fmt.Sprintf("%s %s: %s\n", l, timestamp.Format("2006-01-02T15:04:05.000000000Z07:00"), msg)
 	}
 	return s
 }


### PR DESCRIPTION
`time.RFC3339Nano` is `2006-01-02T15:04:05.999999999Z07:00` which has the
property of stripping trailing zeroes on the nanoseconds field, which has the
annoying property that the prefix used in the log lines is variable length,
making the logs harder to read. e.g. from the logs of my testing on
https://github.com/linuxkit/kubernetes/pull/63:

    [STDOUT  ] 2018-02-13T14:03:45.493977731Z: /var/lib/cni/conf/10-default.conflist:  "plugins": [
    [STDOUT  ] 2018-02-13T14:03:45.494276514Z: /var/lib/cni/conf/10-default.conflist:    {
    [STDOUT  ] 2018-02-13T14:03:45.494720452Z: /var/lib/cni/conf/10-default.conflist:      "type": "bridge",
    [STDOUT  ] 2018-02-13T14:03:45.495101519Z: /var/lib/cni/conf/10-default.conflist:      "bridge": "cni0",
    [STDOUT  ] 2018-02-13T14:03:45.49558236Z: /var/lib/cni/conf/10-default.conflist:      "isDefaultGateway": true,
    [STDOUT  ] 2018-02-13T14:03:45.495936265Z: /var/lib/cni/conf/10-default.conflist:      "ipMasq": true,
    [STDOUT  ] 2018-02-13T14:03:45.496367569Z: /var/lib/cni/conf/10-default.conflist:      "hairpinMode": true,
    [STDOUT  ] 2018-02-13T14:03:45.496752029Z: /var/lib/cni/conf/10-default.conflist:      "ipam": {
    [STDOUT  ] 2018-02-13T14:03:45.497202615Z: /var/lib/cni/conf/10-default.conflist:        "type": "host-local",
    [STDOUT  ] 2018-02-13T14:03:45.497665173Z: /var/lib/cni/conf/10-default.conflist:        "subnet": "192.168.42.0/24",
    [STDOUT  ] 2018-02-13T14:03:45.49810783Z: /var/lib/cni/conf/10-default.conflist:        "gateway": "192.168.42.254"
    [STDOUT  ] 2018-02-13T14:03:45.498438764Z: /var/lib/cni/conf/10-default.conflist:      },

Note how things which were aligned are misalined due to the timestamp.

Switch to a custom format, derived from `time.RFC3339Nano`, which does not
strip the trailing zeroes, this is achieved by turning the `9` placeholders
into `0`.

Signed-off-by: Ian Campbell <ijc@docker.com>