### PR TITLE
Add support for running powershell tests on Unix (well macOS)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -90,9 +90,12 @@ can be use to indicate that the test was cancelled (for whatever
 reason).  Each test must be located in its own sub-directory (together
 with any files it may require).
 
-Currently, a test is a simple shell script called `test.sh`. On
-Windows, tests may also be written as Powershell scripts and the test
-script should be called `test.ps1`.
+Currently, a test is a simple shell script called `test.sh` or
+`test.ps1`. On Windows, `test.ps1` is chosen in preference over
+`test.sh` if both are present. `test.sh` should also work provided
+that MSYS2 `bash` is installed. On Unix type systems `test.sh` is
+chosen over `test.ps1`, but `test.ps1` should also work provided that
+that `powershell` is installed.
 
 There are template [`test.sh`](../etc/templates/test.sh) and
 [`test.ps1`](../etc/templates/test.ps1) files which can be used for

--- a/local/script.go
+++ b/local/script.go
@@ -21,6 +21,11 @@ var (
 
 func init() {
 	if runtime.GOOS != "windows" {
+		t, err := exec.LookPath("pwsh")
+		if err != nil {
+			psExecutable = ""
+		}
+		psExecutable = t
 		return
 	}
 
@@ -46,13 +51,16 @@ func executeScript(script, cwd, name string, args []string, config RunConfig) (R
 	startTime := time.Now()
 	var cmdArgs []string
 	executable := shExecutable
-	if runtime.GOOS == "windows" && filepath.Ext(script) == ".ps1" {
+	if filepath.Ext(script) == ".ps1" {
 		executable = psExecutable
 		cmdArgs = append(cmdArgs, []string{"-NoProfile", "-NonInteractive"}...)
 	} else {
 		if config.Extra {
 			cmdArgs = append(cmdArgs, "-x")
 		}
+	}
+	if executable == "" {
+		return Result{}, fmt.Errorf("Can't find a suitable shell to execute %s", script)
 	}
 	cmdArgs = append(cmdArgs, script)
 	cmdArgs = append(cmdArgs, args...)

--- a/local/types.go
+++ b/local/types.go
@@ -35,6 +35,13 @@ func checkScript(path, name string) (string, error) {
 
 	f := filepath.Join(path, name+".sh")
 	if _, err := os.Stat(f); err != nil {
+		// On non-windows, shell scripts take precedence but we check for powershell too
+		if runtime.GOOS != "windows" {
+			f := filepath.Join(path, name+".ps1")
+			if _, err := os.Stat(f); err == nil {
+				return f, nil
+			}
+		}
 		return "", err
 	}
 	return f, nil


### PR DESCRIPTION
powershell is available on Unix type systems. So this PR adds upport for running `test.ps1` tests on macOS (and probably other Unix type system).

- On windows, `test.ps1` is preferred over `test.sh` if both are present
- On Unix, `test.sh` is preferred over `test.ps1` if both are present

This allows re-using tests cross platform but also to have "native" implementation for a test.