### PR TITLE
Make the "latest" symlink relative

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -279,7 +279,7 @@ func setupResultsDirectory(id string, link bool) (string, error) {
 			}
 		}
 
-		if err := os.Symlink(baseDir, linkPath); err != nil {
+		if err := os.Symlink(id, linkPath); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
Baking in the full absolute path is a problem e.g. if running the tests in a
container (so with a different path). Since the symlink is to another
subdirectory of the same parent directory an absolute link should be completely
fine.

Signed-off-by: Ian Campbell <ijc@docker.com>