### PR TITLE
Fix crash when listing tests with groups being skipped

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -56,14 +56,14 @@ func list(_ *cobra.Command, args []string) error {
 
 	lst := p.List(config)
 	fmt.Fprint(w, "STATE\tTEST\tLABELS\n")
-	for _, t := range lst {
+	for _, r := range lst {
 		var state string
-		if t.TestResult == local.Skip {
+		if r.TestResult == local.Skip {
 			state = yellow("SKIP")
 		} else {
 			state = green("RUN")
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", state, t.Name, t.Test.LabelString())
+		fmt.Fprintf(w, "%s\t%s\t%s\n", state, r.Name, r.Test.LabelString())
 	}
 	w.Flush()
 	return nil

--- a/local/group.go
+++ b/local/group.go
@@ -134,9 +134,12 @@ func (g *Group) List(config RunConfig) []Result {
 	sort.Sort(ByOrder(g.Children))
 
 	if !g.willRun(config) {
+		// Create a fake test to make the labels accessible
+		t := &Test{Labels: g.Labels, NotLabels: g.NotLabels}
 		return []Result{{
 			TestResult: Skip,
 			Name:       g.Name(),
+			Test:       t,
 		}}
 	}
 


### PR DESCRIPTION
`rtf list` for some reason returns a `Result` object which in turn references a `Test` object. For skipped groups, there is not `Test` object and the listing fails. This PR adds a fake/dummy `Test` to the `Result` of skipped groups when listing.

Ideally we would not return a `Result` object on listing the test...

resolves #45 