### PR TITLE
Introduce a type for returning items for List/Info

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -45,8 +45,8 @@ func info(_ *cobra.Command, _ []string) error {
 
 	lst := p.List(config)
 	fmt.Fprintf(w, "NAME\tDESCRIPTION\n")
-	for _, t := range lst {
-		fmt.Fprintf(w, "%s\t%s\n", t.Name, t.Test.Tags.Summary)
+	for _, i := range lst {
+		fmt.Fprintf(w, "%s\t%s\n", i.Name, i.Summary)
 	}
 	w.Flush()
 	return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -56,14 +56,14 @@ func list(_ *cobra.Command, args []string) error {
 
 	lst := p.List(config)
 	fmt.Fprint(w, "STATE\tTEST\tLABELS\n")
-	for _, t := range lst {
+	for _, i := range lst {
 		var state string
-		if t.TestResult == local.Skip {
+		if i.TestResult == local.Skip {
 			state = yellow("SKIP")
 		} else {
 			state = green("RUN")
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", state, t.Name, t.Test.LabelString())
+		fmt.Fprintf(w, "%s\t%s\t%s\n", state, i.Name, i.LabelString())
 	}
 	w.Flush()
 	return nil

--- a/local/group.go
+++ b/local/group.go
@@ -129,23 +129,25 @@ func (g *Group) Name() string {
 }
 
 // List lists all child groups and tests
-func (g *Group) List(config RunConfig) []Result {
-	result := []Result{}
+func (g *Group) List(config RunConfig) []Info {
 	sort.Sort(ByOrder(g.Children))
 
 	if !g.willRun(config) {
-		return []Result{{
+		return []Info{{
 			TestResult: Skip,
 			Name:       g.Name(),
+			Labels:     g.Labels,
+			NotLabels:  g.NotLabels,
 		}}
 	}
 
+	infos := []Info{}
 	for _, c := range g.Children {
 		lst := c.List(config)
-		result = append(result, lst...)
+		infos = append(infos, lst...)
 	}
 
-	return result
+	return infos
 }
 
 // Run will run all child groups and tests

--- a/local/test.go
+++ b/local/test.go
@@ -66,18 +66,18 @@ func (t *Test) LabelString() string {
 }
 
 // List satisfies the TestContainer interface
-func (t *Test) List(config RunConfig) []Result {
-	if !t.willRun(config) {
-		return []Result{{
-			Test:       t,
-			Name:       t.Name(),
-			TestResult: Skip,
-		}}
+func (t *Test) List(config RunConfig) []Info {
+	info := Info{
+		Name:      t.Name(),
+		Summary:   t.Tags.Summary,
+		Labels:    t.Labels,
+		NotLabels: t.NotLabels,
 	}
-	return []Result{{
-		Test: t,
-		Name: t.Name(),
-	}}
+
+	if !t.willRun(config) {
+		info.TestResult = Skip
+	}
+	return []Info{info}
 }
 
 // Run runs a test

--- a/local/test_test.go
+++ b/local/test_test.go
@@ -70,10 +70,6 @@ func TestTestPattern(t *testing.T) {
 		if tst.Name == "test.apps.basic.test" && tst.TestResult != Pass {
 			t.Fatal("test.apps.basic.test matches the TestPattern but is not going to run")
 		}
-		if tst.Test != nil {
-			fmt.Printf("Name: %s Summary: %s CheckLabel: %d\n", tst.Name, tst.Test.Tags.Summary, tst.TestResult)
-		} else {
-			fmt.Printf("Name: %s CheckLabel: %d\n", tst.Name, tst.TestResult)
-		}
+		fmt.Printf("Name: %s Summary: %s CheckLabel: %d\n", tst.Name, tst.Summary, tst.TestResult)
 	}
 }

--- a/local/types.go
+++ b/local/types.go
@@ -101,6 +101,20 @@ type Result struct {
 	Duration        time.Duration
 }
 
+// Info encapsulates the information necessary to list tests and test groups
+type Info struct {
+	Name       string
+	TestResult TestResult
+	Summary    string
+	Labels     map[string]bool
+	NotLabels  map[string]bool
+}
+
+// LabelString returns all labels in a comma separated string
+func (i *Info) LabelString() string {
+	return makeLabelString(i.Labels, i.NotLabels, ", ")
+}
+
 // OSInfo contains information about the OS the tests are running on
 type OSInfo struct {
 	OS      string
@@ -124,7 +138,7 @@ type RunConfig struct {
 // A TestContainer is a container that can hold one or more tests
 type TestContainer interface {
 	Order() int
-	List(config RunConfig) []Result
+	List(config RunConfig) []Info
 	Run(config RunConfig) ([]Result, error)
 }
 


### PR DESCRIPTION
Previously, `rtf list` and `rtf info` would return a `Result`, which, with 6fd55cbec6d1 ("test: Link the test structure into the Result") also included a link to the test. This complicates the logic for just listing tests (or showing the test info). In fact it also broke the case there a entire test group was skipped (see https://github.com/linuxkit/rtf/issues/45)

This commit fixes this by introducing a separate type, `Info`,  being returned for list/info.

resolves #46 