### PR TITLE
sysinfo: add macOS Mojave

### DIFF
--- a/sysinfo/sysinfo_darwin.go
+++ b/sysinfo/sysinfo_darwin.go
@@ -13,6 +13,7 @@ var osxVersionMap = map[string]string{
 	"10.11": "OS X El Capitan",
 	"10.12": "macOS Sierra",
 	"10.13": "macOS High Sierra",
+	"10.14": "macOS Mojave",
 }
 
 func getPlatformSpecifics(info SystemInfo) SystemInfo {

--- a/sysinfo/sysinfo_darwin_test.go
+++ b/sysinfo/sysinfo_darwin_test.go
@@ -12,6 +12,7 @@ func TestResolveNameFromVersion(t *testing.T) {
 		{"10.11.1", "OS X El Capitan"},
 		{"10.12.6", "macOS Sierra"},
 		{"10.13", "macOS High Sierra"},
+		{"10.14.4", "macOS Mojave"},
 	} {
 		if name := resolveNameFromVersion(tt.in); name != tt.out {
 			t.Errorf("resolveNameFromVersion %s\nExpected: %s\nGot: %s\n", tt.in, tt.out, name)


### PR DESCRIPTION
Adds macOS Mojave to osxVersionMap.

Signed-off-by: Russell Cardullo <russellcardullo@gmail.com>