### PR TITLE
Add option to run tests in parallel

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -75,6 +75,7 @@ var (
 	id        string
 	symlink   bool
 	extra     bool
+	parallel  bool
 )
 
 var runCmd = &cobra.Command{
@@ -88,6 +89,7 @@ func init() {
 	flags.StringVarP(&resultDir, "resultdir", "r", "_results", "Directory to place results in")
 	flags.StringVarP(&id, "id", "", "", "ID for this test run")
 	flags.BoolVarP(&extra, "extra", "x", false, "Add extra debug info to log files")
+	flags.BoolVarP(&parallel, "parallel", "p", false, "Run multiple tests in parallel")
 	RootCmd.AddCommand(runCmd)
 }
 
@@ -98,6 +100,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	runConfig := local.NewRunConfig(labels, pattern)
 	runConfig.Extra = extra
+	runConfig.Parallel = parallel
 
 	p, err := local.InitNewProject(caseDir)
 	if err != nil {

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -81,6 +81,17 @@ a simple prefix match, so, if you have tests such as `foo.bar` and
 `foo.bar_baz` and use `./rtf run foo.bar`, it will execute both
 `foo.bar` and `foo.bar_baz`.
 
+## Parallel Execution
+
+You may have tests execute in parallel by using the `-p` flag:
+```
+./rtf run -p
+```
+
+All tests across all groups will run in parallel.  You should ensure
+that individual tests have no dependencies on each other since you
+cannot guarantee any test has completed before another has started
+
 
 ## Writing tests
 

--- a/local/types.go
+++ b/local/types.go
@@ -161,6 +161,7 @@ type RunConfig struct {
 	Labels      map[string]bool
 	NotLabels   map[string]bool
 	TestPattern string
+	Parallel    bool
 }
 
 // A TestContainer is a container that can hold one or more tests


### PR DESCRIPTION
Adds option `--parallel` to run command that will run all tests
across all groups in parallel.

This may not be suitable if the tests are heavily CPU bound as
go does not count threads blocked on system calls (i.e. invoking
shell scripts) towards the GOMAXPROCS limit.