### PR TITLE
add sharding ability

### DIFF
--- a/local/group_test.go
+++ b/local/group_test.go
@@ -1,0 +1,31 @@
+package local
+
+import (
+	"testing"
+)
+
+func TestCalculateShard(t *testing.T) {
+	tests := []struct {
+		size   int
+		shard  int
+		shards int
+		start  int
+		count  int
+	}{
+		{22, 1, 10, 0, 3},
+		{22, 2, 10, 3, 3},
+		{22, 3, 10, 6, 2},
+		{29, 10, 10, 27, 2},
+		{2, 1, 6, 0, 1}, // more shards than elements
+		{2, 2, 6, 1, 1}, // more shards than elements
+		{2, 3, 6, 2, 0}, // more shards than elements
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			if gotStart, gotCount := calculateShard(tt.size, tt.shard, tt.shards); gotStart != tt.start || gotCount != tt.count {
+				t.Errorf("calculateShard() = %v, %v, want %v, %v", gotStart, gotCount, tt.start, tt.count)
+			}
+		})
+	}
+
+}

--- a/local/groupcommand.go
+++ b/local/groupcommand.go
@@ -1,0 +1,43 @@
+package local
+
+import (
+	"fmt"
+
+	"github.com/linuxkit/rtf/logger"
+)
+
+// Run satisfies the TestContainer interface.
+// Run the group init or deinit command.
+func (g GroupCommand) Run(config RunConfig) ([]Result, error) {
+	config.Logger.Log(logger.LevelInfo, fmt.Sprintf("%s::%s()", g.Name, g.Type))
+	res, err := executeScript(g.FilePath, g.Path, "", []string{g.Type}, config)
+	if err != nil {
+		return nil, err
+	}
+	if res.TestResult != Pass {
+		return nil, fmt.Errorf("error running %s:%s", g.FilePath, g.Type)
+	}
+	return []Result{res}, nil
+}
+
+// List satisfies the TestContainer interface
+func (g GroupCommand) List(config RunConfig) []Info {
+	info := Info{
+		Name: g.Name,
+	}
+
+	return []Info{info}
+}
+
+// Order returns a tests order
+func (g GroupCommand) Order() int {
+	if g.Type == "init" {
+		return 0
+	}
+	return 1
+}
+
+// Gather satisfies the TestContainer interface
+func (g GroupCommand) Gather(config RunConfig, count int) ([]TestContainer, int) {
+	return []TestContainer{&g}, 0
+}

--- a/local/project.go
+++ b/local/project.go
@@ -1,0 +1,72 @@
+package local
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+// NewProject creates a new top-level Group at the provided path
+func NewProject(path string) (*Project, error) {
+	if !filepath.IsAbs(path) {
+		var err error
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	g := &Project{&Group{Parent: nil, Path: path}, 0, 0}
+	return g, nil
+}
+
+// InitNewProject creates a new Group, and calls Init() on it
+func InitNewProject(path string) (*Project, error) {
+	project, err := NewProject(path)
+	if err != nil {
+		return project, err
+	}
+	return project, project.Init()
+}
+
+// SetShard returns a subset of the group based on the shards
+func (p *Project) SetShard(shard, totalShards int) error {
+	if shard < 1 || shard > totalShards {
+		return errors.New("shard must be between 1 and totalShards")
+	}
+	if totalShards < 1 {
+		return fmt.Errorf("totalShards must be greater than 0")
+	}
+	if totalShards == 1 {
+		return nil
+	}
+	p.shard = shard
+	p.totalShards = totalShards
+
+	return nil
+}
+
+// Run runs all child groups and tests, limited by the provided shards
+func (p *Project) Run(config RunConfig) ([]Result, error) {
+	// if we are sharded, walk the tree to create a list of the tests to run
+	if p.totalShards <= 1 {
+		return p.Group.Run(config)
+	}
+
+	infos := p.Group.List(config)
+	start, count := calculateShard(len(infos), p.shard, p.totalShards)
+
+	config.start = start
+	config.count = count
+
+	return p.Group.Run(config)
+}
+
+// List lists all child groups and tests, limited by the provided shards
+func (p *Project) List(config RunConfig) []Info {
+	infos := p.Group.List(config)
+	if p.totalShards <= 1 {
+		return infos
+	}
+	start, count := calculateShard(len(infos), p.shard, p.totalShards)
+	return infos[start : start+count]
+}

--- a/local/test.go
+++ b/local/test.go
@@ -81,6 +81,14 @@ func (t *Test) List(config RunConfig) []Info {
 	return []Info{info}
 }
 
+// Gather satisfies the TestContainer interface
+func (t *Test) Gather(config RunConfig, count int) ([]TestContainer, int) {
+	if (config.start == 0 && config.count == 0) || (count >= config.start && config.start+config.count > count) {
+		return []TestContainer{t}, 1
+	}
+	return nil, 0
+}
+
 // Run runs a test
 func (t *Test) Run(config RunConfig) ([]Result, error) {
 	var results []Result

--- a/local/types.go
+++ b/local/types.go
@@ -48,6 +48,13 @@ func checkScript(path, name string) (string, error) {
 	return f, nil
 }
 
+// Project is a group of tests and other groups with a few higher level functions
+type Project struct {
+	*Group
+	shard       int
+	totalShards int
+}
+
 // Group is a group of tests and other groups
 type Group struct {
 	Parent        *Group
@@ -162,13 +169,25 @@ type RunConfig struct {
 	NotLabels   map[string]bool
 	TestPattern string
 	Parallel    bool
+	IncludeInit bool
+	start       int
+	count       int
 }
 
-// A TestContainer is a container that can hold one or more tests
+// GroupCommand is a command that is runnable, either a test or pre/post script.
+type GroupCommand struct {
+	Name     string
+	Type     string
+	FilePath string
+	Path     string
+}
+
+// TestContainer is a container that can hold one or more tests
 type TestContainer interface {
 	Order() int
 	List(config RunConfig) []Info
 	Run(config RunConfig) ([]Result, error)
+	Gather(config RunConfig, count int) ([]TestContainer, int)
 }
 
 // ByOrder implements the sort.Sorter interface for TestContainer


### PR DESCRIPTION
Adds the ability to shard runs. Does not really affect parallel (which I haven't seen much used anyways), but does let you do:

```
rtf run proj.build -s 1/6
```

That will find all of the test cases, split them into 6 shards, and run just the 1st shard. The consistency allows you to parallelize this among, e.g. multiple CI runners.

Also adds a test of the sharding algorithm.

A few points:

* I used `--shards 1/6` rather than `--shard 1 --total-shards 6` because it makes it easier for humans to understand and parse, and was easier to process.
* I used 1-base rather than 0-base (i.e. 1/6 to 6/6 rather than 0/6 to 5/6 or 0/5 to 5/5), again, because it is easier for humans
* The sharding algorithm divides evenly, allocating extra weight to the first chunks. So splitting 8 tests into 5 shards will give shards of 2, 2, 2, 1, 1.
