### PR TITLE
simplify shard algorithm to fix

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -34,7 +34,7 @@ func init() {
 	flags := listCmd.Flags()
 	// shardPattern is 1-based (1/10, 3/10, 10/10) rather than normal computer 0-based (0/9, 2/9, 9/9), because it is easier for
 	// humans to understand when calling the CLI.
-	flags.StringVarP(&shardPattern, "shard", "s", "", "which shard to run, in form of 'N/M' where N is the shard number and M is the total number of shards, smallest shard number is 1")
+	flags.StringVarP(&shardPattern, "shard", "s", "", "which shard to run, in form of 'N/M' where N is the shard number and M is the total number of shards, smallest shard number is 1. Shards are applied only to tests that would run, not those that would be skipped.")
 	RootCmd.AddCommand(listCmd)
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,7 +93,7 @@ func init() {
 	flags.BoolVarP(&parallel, "parallel", "p", false, "Run multiple tests in parallel")
 	// shardPattern is 1-based (1/10, 3/10, 10/10) rather than normal computer 0-based (0/9, 2/9, 9/9), because it is easier for
 	// humans to understand when calling the CLI.
-	flags.StringVarP(&shardPattern, "shard", "s", "", "which shard to run, in form of 'N/M' where N is the shard number and M is the total number of shards, smallest shard number is 1")
+	flags.StringVarP(&shardPattern, "shard", "s", "", "which shard to run, in form of 'N/M' where N is the shard number and M is the total number of shards, smallest shard number is 1. Shards are applied only to tests that would run, not those that would be skipped.")
 	RootCmd.AddCommand(runCmd)
 }
 

--- a/local/groupcommand.go
+++ b/local/groupcommand.go
@@ -38,6 +38,6 @@ func (g GroupCommand) Order() int {
 }
 
 // Gather satisfies the TestContainer interface
-func (g GroupCommand) Gather(config RunConfig, count int) ([]TestContainer, int) {
+func (g GroupCommand) Gather(config RunConfig) ([]TestContainer, int) {
 	return []TestContainer{&g}, 0
 }

--- a/local/test.go
+++ b/local/test.go
@@ -82,8 +82,8 @@ func (t *Test) List(config RunConfig) []Info {
 }
 
 // Gather satisfies the TestContainer interface
-func (t *Test) Gather(config RunConfig, count int) ([]TestContainer, int) {
-	if (config.start == 0 && config.count == 0) || (count >= config.start && config.start+config.count > count) {
+func (t *Test) Gather(config RunConfig) ([]TestContainer, int) {
+	if len(config.restrictToTests) == 0 || config.restrictToTests[t.Name()] {
 		return []TestContainer{t}, 1
 	}
 	return nil, 0
@@ -101,6 +101,7 @@ func (t *Test) Run(config RunConfig) ([]Result, error) {
 			TestResult: Skip,
 		}}, nil
 	}
+	config.Logger.Log(logger.LevelInfo, fmt.Sprintf("Running test %s", t.Name()))
 
 	if t.Tags.Repeat == 0 {
 		// Always run at least once

--- a/local/types.go
+++ b/local/types.go
@@ -160,18 +160,17 @@ type OSInfo struct {
 
 // RunConfig contains runtime configuration information
 type RunConfig struct {
-	Extra       bool
-	CaseDir     string
-	LogDir      string
-	Logger      logger.LogDispatcher
-	SystemInfo  sysinfo.SystemInfo
-	Labels      map[string]bool
-	NotLabels   map[string]bool
-	TestPattern string
-	Parallel    bool
-	IncludeInit bool
-	start       int
-	count       int
+	Extra           bool
+	CaseDir         string
+	LogDir          string
+	Logger          logger.LogDispatcher
+	SystemInfo      sysinfo.SystemInfo
+	Labels          map[string]bool
+	NotLabels       map[string]bool
+	TestPattern     string
+	Parallel        bool
+	IncludeInit     bool
+	restrictToTests map[string]bool
 }
 
 // GroupCommand is a command that is runnable, either a test or pre/post script.
@@ -187,7 +186,7 @@ type TestContainer interface {
 	Order() int
 	List(config RunConfig) []Info
 	Run(config RunConfig) ([]Result, error)
-	Gather(config RunConfig, count int) ([]TestContainer, int)
+	Gather(config RunConfig) ([]TestContainer, int)
 }
 
 // ByOrder implements the sort.Sorter interface for TestContainer


### PR DESCRIPTION
The previous one was too complicate and sometimes would have empty shards. This simplifies it, removes redundancy, and therefore also fixes it.

Also adds some useful reporting.